### PR TITLE
feat(audit): totals-trail

### DIFF
--- a/src/Vera.Azure/HostBuilderExtensions.cs
+++ b/src/Vera.Azure/HostBuilderExtensions.cs
@@ -162,6 +162,9 @@ namespace Vera.Azure
                 collection.AddSingleton<IInvoiceStore>(_ => new CosmosInvoiceStore(
                     cosmosClient.GetContainer(cosmosOptions.Database, cosmosContainerOptions.Invoices)));
 
+                collection.AddSingleton<IGrandTotalAuditTrailStore>(_ => new CosmosGrandTotalAuditTrailStore(
+                    cosmosClient.GetContainer(cosmosOptions.Database, cosmosContainerOptions.Trails)));
+
                 collection.AddSingleton<ICompanyStore>(_ => new CosmosCompanyStore(
                     cosmosClient.GetContainer(cosmosOptions.Database, cosmosContainerOptions.Companies)));
 

--- a/src/Vera.Azure/Stores/ChainDocument.cs
+++ b/src/Vera.Azure/Stores/ChainDocument.cs
@@ -14,5 +14,6 @@ namespace Vera.Azure.Stores
         public int Sequence { get; set; }
         public Signature Signature { get; set; }
         public string PartitionKey { get; set; }
+        public decimal CumulatedValue { get; set; }
     }
 }

--- a/src/Vera.Azure/Stores/CosmosChainable.cs
+++ b/src/Vera.Azure/Stores/CosmosChainable.cs
@@ -23,7 +23,7 @@ namespace Vera.Azure.Stores
             _last = last;
         }
 
-        public async Task Append(Signature signature)
+        public async Task Append(Signature signature, decimal cumulatedValue = 0)
         {
             var partitionKey = new PartitionKey(_partitionKeyValue);
 
@@ -32,7 +32,8 @@ namespace Vera.Azure.Stores
                 Id = Guid.NewGuid(),
                 Sequence = NextSequence,
                 Signature = signature,
-                PartitionKey = _partitionKeyValue
+                PartitionKey = _partitionKeyValue,
+                CumulatedValue = cumulatedValue
             };
 
             var tx = _container.CreateTransactionalBatch(partitionKey);
@@ -58,5 +59,6 @@ namespace Vera.Azure.Stores
 
         public int NextSequence => _last?.Sequence + 1 ?? 1;
         public Signature? Signature => _last?.Signature;
+        public decimal CumulatedValue => _last?.CumulatedValue ?? 0;
     }
 }

--- a/src/Vera.Azure/Stores/CosmosGrandTotalAuditTrailStore.cs
+++ b/src/Vera.Azure/Stores/CosmosGrandTotalAuditTrailStore.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Azure.Cosmos;
+using System;
+using System.Threading.Tasks;
+using Vera.Models;
+using Vera.Stores;
+
+namespace Vera.Azure.Stores
+{
+    public class CosmosGrandTotalAuditTrailStore : IGrandTotalAuditTrailStore
+    {
+        private readonly Container _container;
+
+        public CosmosGrandTotalAuditTrailStore(Container container)
+        {
+            _container = container;
+        }
+
+        public async Task<GrandTotalAuditTrail> Create(Invoice invoice, decimal grandTotal)
+        {
+            var trail = new GrandTotalAuditTrail
+            {
+                Id = Guid.NewGuid(),
+                InvoiceId = invoice.Id,
+                SupplierId = invoice.Supplier.Id,
+                GrandTotal = grandTotal + invoice.Totals.Gross
+            };
+
+            var document = ToDocument(trail);
+
+            await _container.CreateItemAsync(document, new PartitionKey(document.PartitionKey));
+
+            return trail;
+        }
+
+        public async Task Delete(GrandTotalAuditTrail grandTotalAuditTrail)
+        {
+            var response = await _container.DeleteItemStreamAsync(
+                grandTotalAuditTrail.Id.ToString(),
+                new PartitionKey(grandTotalAuditTrail.SupplierId.ToString())
+            );
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        private static Document<GrandTotalAuditTrail> ToDocument(GrandTotalAuditTrail trail)
+        {
+            return new(
+                t => t.Id,
+                t => t.SupplierId.ToString(),
+                trail
+            );
+        }
+    }
+}

--- a/src/Vera.Germany/ComponentFactory.cs
+++ b/src/Vera.Germany/ComponentFactory.cs
@@ -45,6 +45,12 @@ namespace Vera.Germany
             return new UniqueBucketPerSupplierGenerator();
         }
 
+        public IBucketGenerator<Invoice> CreateGrandTotalAuditTrailBucketGenerator()
+        {
+            //return new GrandTotalAuditTrailBucketGenerator();
+            throw new NotImplementedException();
+        }
+
         public IInvoiceNumberGenerator CreateInvoiceNumberGenerator()
         {
             return new InvoiceSequenceNumberGenerator();

--- a/src/Vera.Norway/ComponentFactory.cs
+++ b/src/Vera.Norway/ComponentFactory.cs
@@ -49,6 +49,11 @@ namespace Vera.Norway
             return new InvoiceBucketGenerator();
         }
 
+        public IBucketGenerator<Invoice> CreateGrandTotalAuditTrailBucketGenerator()
+        {
+            return new GrandTotalAuditTrailBucketGenerator();
+        }
+
         public IInvoiceNumberGenerator CreateInvoiceNumberGenerator()
         {
             return new InvoiceNumberGenerator();

--- a/src/Vera.Poland/ComponentFactory.cs
+++ b/src/Vera.Poland/ComponentFactory.cs
@@ -31,6 +31,11 @@ namespace Vera.Poland
             throw new NotImplementedException();
         }
 
+        public IBucketGenerator<Invoice> CreateGrandTotalAuditTrailBucketGenerator()
+        {
+            throw new NotImplementedException();
+        }
+
         public IInvoiceNumberGenerator CreateInvoiceNumberGenerator()
         {
             throw new NotImplementedException();

--- a/src/Vera.Portugal/ComponentFactory.cs
+++ b/src/Vera.Portugal/ComponentFactory.cs
@@ -50,6 +50,11 @@ namespace Vera.Portugal
             return new InvoiceBucketGenerator();
         }
 
+        public IBucketGenerator<Invoice> CreateGrandTotalAuditTrailBucketGenerator()
+        {
+            return new GrandTotalAuditTrailBucketGenerator();
+        }
+
         public IInvoiceNumberGenerator CreateInvoiceNumberGenerator()
         {
             return new InvoiceNumberGenerator();

--- a/src/Vera.Portugal/Invoices/PortugalInvoiceHandlerFactory.cs
+++ b/src/Vera.Portugal/Invoices/PortugalInvoiceHandlerFactory.cs
@@ -19,6 +19,7 @@ namespace Vera.Portugal.Invoices
         private readonly ISupplierStore _supplierStore;
         private readonly IPeriodStore _periodStore;
         private readonly IWorkingDocumentStore _wdStore;
+        private readonly IGrandTotalAuditTrailStore _grandTotalAuditTrailStore;
 
         public PortugalInvoiceHandlerFactory(
             ILoggerFactory loggerFactory,
@@ -27,7 +28,8 @@ namespace Vera.Portugal.Invoices
             ILocker locker,
             ISupplierStore supplierStore,
             IPeriodStore periodStore,
-            IWorkingDocumentStore wdStore
+            IWorkingDocumentStore wdStore,
+            IGrandTotalAuditTrailStore grandTotalAuditTrailStore
         )
         {
             _loggerFactory = loggerFactory;
@@ -37,6 +39,7 @@ namespace Vera.Portugal.Invoices
             _supplierStore = supplierStore;
             _periodStore = periodStore;
             _wdStore = wdStore;
+            _grandTotalAuditTrailStore = grandTotalAuditTrailStore;
         }
 
         public IHandlerChain<Invoice> Create(IComponentFactory factory)
@@ -59,7 +62,9 @@ namespace Vera.Portugal.Invoices
                 _invoiceStore,
                 signer,
                 factory.CreateInvoiceNumberGenerator(),
-                bucketGenerator
+                bucketGenerator,
+                factory.CreateGrandTotalAuditTrailBucketGenerator(),
+                _grandTotalAuditTrailStore
             );
 
             wdHandler.WithNext(persistenceHandler);

--- a/src/Vera.Sweden/ComponentFactory.cs
+++ b/src/Vera.Sweden/ComponentFactory.cs
@@ -54,6 +54,11 @@ namespace Vera.Sweden
             throw new System.NotImplementedException();
         }
 
+        public IBucketGenerator<Invoice> CreateGrandTotalAuditTrailBucketGenerator()
+        {
+            throw new System.NotImplementedException();
+        }
+
         public IInvoiceNumberGenerator CreateInvoiceNumberGenerator()
         {
             throw new System.NotImplementedException();

--- a/src/Vera/Invoices/GrandTotalAuditTrailBucketGenerator.cs
+++ b/src/Vera/Invoices/GrandTotalAuditTrailBucketGenerator.cs
@@ -1,0 +1,10 @@
+﻿using Vera.Dependencies;
+using Vera.Models;
+
+namespace Vera.Invoices
+{
+    public class GrandTotalAuditTrailBucketGenerator : IBucketGenerator<Invoice>
+    {
+        public string Generate(Invoice entity) => $"{entity.Supplier.Id}-{nameof(Invoice)}";
+    }
+}

--- a/src/Vera/Invoices/IInvoiceComponentFactory.cs
+++ b/src/Vera/Invoices/IInvoiceComponentFactory.cs
@@ -9,6 +9,7 @@ namespace Vera.Invoices
     {
         IEnumerable<IInvoiceValidator> CreateInvoiceValidators();
         IBucketGenerator<Invoice> CreateInvoiceBucketGenerator();
+        IBucketGenerator<Invoice> CreateGrandTotalAuditTrailBucketGenerator();
         IInvoiceNumberGenerator CreateInvoiceNumberGenerator();
         IInvoiceSigner CreateInvoiceSigner();
     }

--- a/src/Vera/Invoices/IInvoiceHandlerFactory.cs
+++ b/src/Vera/Invoices/IInvoiceHandlerFactory.cs
@@ -21,6 +21,7 @@ namespace Vera.Invoices
         private readonly ILocker _locker;
         private readonly ISupplierStore _supplierStore;
         private readonly IPeriodStore _periodStore;
+        private readonly IGrandTotalAuditTrailStore _grandTotalAuditTrailStore;
 
         public InvoiceHandlerFactory(
             ILoggerFactory loggerFactory,
@@ -28,7 +29,8 @@ namespace Vera.Invoices
             IChainStore chainStore,
             ILocker locker,
             ISupplierStore supplierStore,
-            IPeriodStore periodStore
+            IPeriodStore periodStore,
+            IGrandTotalAuditTrailStore grandTotalAuditTrailStore
         )
         {
             _loggerFactory = loggerFactory;
@@ -37,6 +39,7 @@ namespace Vera.Invoices
             _locker = locker;
             _supplierStore = supplierStore;
             _periodStore = periodStore;
+            _grandTotalAuditTrailStore = grandTotalAuditTrailStore;
         }
 
         public IHandlerChain<Invoice> Create(IComponentFactory factory)
@@ -49,7 +52,9 @@ namespace Vera.Invoices
                 _invoiceStore,
                 factory.CreateInvoiceSigner(),
                 factory.CreateInvoiceNumberGenerator(),
-                factory.CreateInvoiceBucketGenerator()
+                factory.CreateInvoiceBucketGenerator(),
+                factory.CreateGrandTotalAuditTrailBucketGenerator(),
+                _grandTotalAuditTrailStore
             );
 
             head.WithNext(new InvoiceOpenPeriodHandler(_periodStore))

--- a/src/Vera/Models/GrandTotalAuditTrail.cs
+++ b/src/Vera/Models/GrandTotalAuditTrail.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vera.Models
+{
+    public class GrandTotalAuditTrail
+    {
+        public Guid Id { get; set; }
+        public Guid SupplierId { get; set; }
+        public Guid InvoiceId { get; set; }
+        public decimal GrandTotal { get; set; }
+    }
+}

--- a/src/Vera/Stores/IChainable.cs
+++ b/src/Vera/Stores/IChainable.cs
@@ -10,7 +10,7 @@ namespace Vera.Stores
         /// </summary>
         /// <param name="signature"></param>
         /// <returns></returns>
-        Task Append(Signature signature);
+        Task Append(Signature signature, decimal cumulatedValue = 0);
         
         /// <summary>
         /// Sequence that will follow this chainable.
@@ -22,5 +22,10 @@ namespace Vera.Stores
         /// chainable in the link.
         /// </summary>
         Signature? Signature { get; }
+
+        /// <summary>
+        /// The Cumulated Value of the entire chain
+        /// </summary>
+        decimal CumulatedValue { get; }
     }
 }

--- a/src/Vera/Stores/IGrandTotalAuditTrailStore.cs
+++ b/src/Vera/Stores/IGrandTotalAuditTrailStore.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using Vera.Models;
+
+namespace Vera.Stores
+{
+    public interface IGrandTotalAuditTrailStore
+    {
+        Task<GrandTotalAuditTrail> Create(Invoice invoice, decimal grandTotal);
+        Task Delete(GrandTotalAuditTrail grandTotalAuditTrail);
+    }
+}

--- a/test/Vera.Norway.Integration.Tests/InvoiceServiceTests.cs
+++ b/test/Vera.Norway.Integration.Tests/InvoiceServiceTests.cs
@@ -18,6 +18,30 @@ namespace Vera.Norway.Integration.Tests
             _setup = fixture.CreateSetup();
         }
 
+        /*[Fact]
+        public async Task Should_create_multiple_invoices_and_their_grand_totals_and_chain_items()
+        {
+            var client = await _setup.CreateClient(Constants.Account);
+
+            var builder = new InvoiceBuilder();
+            var director = new InvoiceDirector(builder, Guid.Parse(client.AccountId), client.SupplierSystemId);
+            director.ConstructAnonymousWithSingleProductPaidWithCash();
+
+            await client.OpenPeriod();
+            var registerSystemId = await client.OpenRegister(100m);
+
+            var invoice = builder.Result;
+            invoice.RegisterSystemId = registerSystemId;
+
+            var createInvoiceRequest = new CreateInvoiceRequest
+            {
+                Invoice = invoice.Pack()
+            };
+            var createInvoiceReply = await client.Invoice.CreateAsync(createInvoiceRequest, client.AuthorizedMetadata);
+            createInvoiceReply = await client.Invoice.CreateAsync(createInvoiceRequest, client.AuthorizedMetadata);
+            createInvoiceReply = await client.Invoice.CreateAsync(createInvoiceRequest, client.AuthorizedMetadata);
+        }*/
+
         [Fact]
         public async Task Should_be_able_to_create_an_invoice()
         {


### PR DESCRIPTION
the InvoicePersistenceHandler was edited in order to handle the persistence and update of the Grand Total Audit as well in order to keep these linked as a atomic transaction.

The Handle in InvoicePersistenceHandler creates the invoice and stores it and after that it gets the cumulative total from the last GrantTotalAuditTrail and uses it to creat a new one with the previous total and the Gross Total of the current invoice. The only way this could be achieved was by adding a new Cumulative Value in the Chainable class as well, because I could not find any way of getting the (last) Trail item just by using the information in the last Chainable (and would also require a new call to the database.

This PR also includes changes in different ComponentFactories since new a new Store interface was added that needs to be taken into consideration on every Dependency Injection level.